### PR TITLE
Fix v23.06 ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
           SofaPython3_ROOT="$GITHUB_WORKSPACE/SofaPython3"
           mkdir -p "${{ runner.temp }}/sp3_tmp/zip" "${{ runner.temp }}/sp3_tmp/binaries" "$SofaPython3_ROOT"
           url="https://github.com/sofa-framework/SofaPython3/releases/download"
-          url="${url}/release-master-nightly/SofaPython3_master-nightly_python-${{ matrix.python_version }}_for-SOFA-${{ matrix.sofa_branch }}_${{ runner.os }}.zip"
+          url="${url}/release-${{ matrix.sofa_branch }}/SofaPython3_${{ matrix.sofa_branch }}_python-${{ matrix.python_version }}_for-SOFA-${{ matrix.sofa_branch }}_${{ runner.os }}.zip"
           echo "Getting SofaPython3 from $url"
           curl --output "${{ runner.temp }}/sp3_tmp/SofaPython3.zip" -L $url
           unzip -qq "${{ runner.temp }}/sp3_tmp/SofaPython3.zip" -d "${{ runner.temp }}/sp3_tmp/binaries"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-11, windows-2019]
-        sofa_branch: [master]
+        sofa_branch: [v23.06]
         python_version: ['3.8']
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,8 @@ jobs:
           with:
             name: ${{ github.ref_name }}
             tag_name: release-${{ github.ref_name }}
-            fail_on_unmatched_files: true 
+            fail_on_unmatched_files: false 
             files: |
               artifacts/CosseratPlugin_*_Linux.zip
               artifacts/CosseratPlugin_*_Windows.zip
+              artifacts/CosseratPlugin_*_macOS.zip


### PR DESCRIPTION
- Update ci.yml to run CI on the v23.06 branch (and not master)
- Temporarily disable MacOS build as it seems down