### PR TITLE
Fix install SofaPython3 CI action.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,11 @@ jobs:
           SofaPython3_ROOT="$GITHUB_WORKSPACE/SofaPython3"
           mkdir -p "${{ runner.temp }}/sp3_tmp/zip" "${{ runner.temp }}/sp3_tmp/binaries" "$SofaPython3_ROOT"
           url="https://github.com/sofa-framework/SofaPython3/releases/download"
-          url="${url}/release-master-nightly/SofaPython3_master-nightly_python-${{ matrix.python_version }}_for-SOFA-${{ matrix.sofa_branch }}_${{ runner.os }}.zip"
+          if [[ "${{ matrix.sofa_branch }}" == "master" ]]; then
+            url="${url}/release-master-nightly/SofaPython3_master-nightly_python-${{ matrix.python_version }}_for-SOFA-master_${{ runner.os }}.zip"
+          else
+            url="${url}/release-${{ matrix.sofa_branch }}/SofaPython3_${{ matrix.sofa_branch }}_python-${{ matrix.python_version }}_for-SOFA-${{ matrix.sofa_branch }}_${{ runner.os }}.zip"
+          fi
           echo "Getting SofaPython3 from $url"
           curl --output "${{ runner.temp }}/sp3_tmp/SofaPython3.zip" -L $url
           unzip -qq "${{ runner.temp }}/sp3_tmp/SofaPython3.zip" -d "${{ runner.temp }}/sp3_tmp/binaries"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,11 +54,7 @@ jobs:
           SofaPython3_ROOT="$GITHUB_WORKSPACE/SofaPython3"
           mkdir -p "${{ runner.temp }}/sp3_tmp/zip" "${{ runner.temp }}/sp3_tmp/binaries" "$SofaPython3_ROOT"
           url="https://github.com/sofa-framework/SofaPython3/releases/download"
-          if [[ "${{ matrix.sofa_branch }}" == "master" ]]; then
-            url="${url}/release-master-nightly/SofaPython3_master-nightly_python-${{ matrix.python_version }}_for-SOFA-master_${{ runner.os }}.zip"
-          else
-            url="${url}/release-${{ matrix.sofa_branch }}/SofaPython3_${{ matrix.sofa_branch }}_python-${{ matrix.python_version }}_for-SOFA-${{ matrix.sofa_branch }}_${{ runner.os }}.zip"
-          fi
+          url="${url}/release-${{ matrix.sofa_branch }}/SofaPython3_${{ matrix.sofa_branch }}_python-${{ matrix.python_version }}_for-SOFA-${{ matrix.sofa_branch }}_${{ runner.os }}.zip"
           echo "Getting SofaPython3 from $url"
           curl --output "${{ runner.temp }}/sp3_tmp/SofaPython3.zip" -L $url
           unzip -qq "${{ runner.temp }}/sp3_tmp/SofaPython3.zip" -d "${{ runner.temp }}/sp3_tmp/binaries"


### PR DESCRIPTION
This was initially done for #81.
This PR intend to fix broken CI when building a release branch, defined in the `sofa_branch` field in the `ci.yml`: https://github.com/SofaDefrost/Cosserat/blob/ca56f590090fb1da9dc302fa78c826d746e952c2/.github/workflows/ci.yml#L18
For a given plugin release that needs to install SofaPython3 plugin, the expected behavior should be to install the corresponding release of the plugin (instead of `master-nightly`). 
So far, the path was broken as it was a mix of current `sofa_branch` value and hard-coded `master` or `master-nightly`.
This solution should be fine as long we limit the scope of branches that can be specified in the `sofa_branch` field of `ci.yml` to `master` and release branches, as for non-master branches it will try to install a release of SofaPython3 defined by the branch name, and it will only exists if it a release. This is open for discussion.
This should be integrated into master of all plugins for which the CI rely on SofaPython3 installation for the future releases.
