### PR TITLE
Allow python3 site-package to be modified

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,8 +113,10 @@ else()
     find_package(SofaPython3 QUIET)
 endif()
 if(SofaPython3Tools OR SofaPython3_FOUND)
-    message("-- Python3 packages will be installed.")
-    set(SP3_PYTHON_PACKAGES_DIRECTORY "python3/site-packages")
+    if(NOT SP3_PYTHON_PACKAGES_DIRECTORY)
+        set(SP3_PYTHON_PACKAGES_DIRECTORY "python3/site-packages")
+    endif()
+    message("-- Python3 packages will be installed in ${SP3_PYTHON_PACKAGES_DIRECTORY}.")
     # SP3_add_python_package(
     #         SOURCE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/python3/cosserat
     #         TARGET_DIRECTORY cosserat


### PR DESCRIPTION
This is similar to what have been done to other SOFA plugins having python packages (see MOR for example: https://github.com/SofaDefrost/ModelOrderReduction/pull/72 ).

If merged, this PR will need to be backported to v23.12.

----
For python 3, the CMakeLists sets the SP3_PYTHON_PACKAGES_DIRECTORY cmake variable to python3/site-package. However, a more standard approach is to install to the site-package directory in the form python<X.Y>/site-package for a Python version X.Y, as it is then automatically imported by default thanks to the site module (see https://docs.python.org/3/library/site.html#module-site ).
Also, whereas it is possible to change the SP3_PYTHON_PACKAGES_DIRECTORY cmake variable for SofaPython3 (e.g. to the pythonX.Y/site-package value), it cannot be changed for this plugin, so the python3/site-package value is fixed. This leads to an inconsistent python packages installation if SP3_PYTHON_PACKAGES_DIRECTORY has been changed in SofaPython3 install.
This PR would enable to automatically inherits by default the value of SP3_PYTHON_PACKAGES_DIRECTORY that is read from the SofaPython3Config.cmake at the find_package(SofaPython3) call, and which corresponds to the SP3_PYTHON_PACKAGES_DIRECTORY of the SofaPython3 python packages directory. If SofaPython3 is not found, then SP3_PYTHON_PACKAGES_DIRECTORY won't be set and still can be user defined at the cmake configure, or just kept unspecified and then it will fallback to its default value.