### PR TITLE
Apply new registration mechanism

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ sofa_find_package(SoftRobots QUIET)
 if(SoftRobots_FOUND)
     message("-- Found dependency : 'SoftRobots' plugin .")
 
+    set(COSSERAT_USES_SOFTROBOTS ON)
     list(APPEND HEADER_FILES
         ${SRC_ROOT_DIR}/constraint/CosseratActuatorConstraint.h
         ${SRC_ROOT_DIR}/constraint/CosseratActuatorConstraint.inl

--- a/src/Cosserat/config.h.in
+++ b/src/Cosserat/config.h.in
@@ -42,11 +42,15 @@
 
 /** \mainpage
   This is the plugin for the Discret Cosserat Plugin
-*/
+**/
+#cmakedefine COSSERAT_USES_SOFTROBOTS
 
 namespace Cosserat
 {
     SOFA_COSSERAT_API void init();
     constexpr const char *MODULE_NAME = "@PROJECT_NAME@";
     constexpr const char *MODULE_VERSION = "@PROJECT_VERSION@";
+
+
+
 }

--- a/src/Cosserat/constraint/CosseratActuatorConstraint.cpp
+++ b/src/Cosserat/constraint/CosseratActuatorConstraint.cpp
@@ -28,19 +28,16 @@
 *                                                                             *
 ******************************************************************************/
 
-
-#include "CosseratActuatorConstraint.inl"
+#include <Cosserat/constraint/CosseratActuatorConstraint.inl>
 #include <Cosserat/config.h>
 #include <sofa/core/ObjectFactory.h>
 
-namespace Cosserat
+template class SOFA_COSSERAT_API sofa::component::constraintset::CosseratActuatorConstraint<sofa::defaulttype::Vec3Types>;
 
+namespace Cosserat
 {
 
-//////////////////////////////////////CosseratActuatorConstraintConstraintResolution1Dof/////////////////////////////////////////////
 using namespace sofa::defaulttype;
-using namespace sofa::helper;
-using namespace sofa::core;
 
 void registerCosseratActuatorConstraint(sofa::core::ObjectFactory* factory)
 {

--- a/src/Cosserat/constraint/CosseratActuatorConstraint.cpp
+++ b/src/Cosserat/constraint/CosseratActuatorConstraint.cpp
@@ -48,14 +48,5 @@ void registerCosseratActuatorConstraint(sofa::core::ObjectFactory* factory)
             .add< sofa::component::constraintset::CosseratActuatorConstraint<Vec3Types> >(true));
 }
 
-;
-////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-// Force template specialization for the most common sofa type.
-// This goes with the extern template declaration in the .h. Declaring extern template
-// avoid the code generation of the template for each compilation unit.
-// see: http://www.stroustrup.com/C++11FAQ.html#extern-templates
-//template class CosseratActuatorConstraint<Vec3Types>;
-
 } // namespace sofa
 

--- a/src/Cosserat/constraint/CosseratActuatorConstraint.cpp
+++ b/src/Cosserat/constraint/CosseratActuatorConstraint.cpp
@@ -33,7 +33,8 @@
 #include <Cosserat/config.h>
 #include <sofa/core/ObjectFactory.h>
 
-namespace sofa::component::constraintset
+namespace Cosserat
+
 {
 
 //////////////////////////////////////CosseratActuatorConstraintConstraintResolution1Dof/////////////////////////////////////////////
@@ -47,8 +48,11 @@ using namespace sofa::core;
 // 1-RegisterObject("description") + .add<> : Register the component
 // 2-.add<>(true) : Set default template
 
-int CosseratActuatorConstraintClass = RegisterObject("Simulate cable actuation.")
-.add< CosseratActuatorConstraint<Vec3Types> >(true)
+void registerCosseratActuatorConstraint(sofa::core::ObjectFactory* factory)
+{
+      factory->registerObjects(sofa::core::ObjectRegistrationData("Simulate cable actuation.")
+            .add< sofa::component::constraintset::CosseratActuatorConstraint<Vec3Types> >(true));
+}
 
 ;
 ////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/Cosserat/constraint/CosseratActuatorConstraint.cpp
+++ b/src/Cosserat/constraint/CosseratActuatorConstraint.cpp
@@ -42,12 +42,6 @@ using namespace sofa::defaulttype;
 using namespace sofa::helper;
 using namespace sofa::core;
 
-////////////////////////////////////////////    FACTORY    //////////////////////////////////////////////
-// Registering the component
-// see: http://wiki.sofa-framework.org/wiki/ObjectFactory
-// 1-RegisterObject("description") + .add<> : Register the component
-// 2-.add<>(true) : Set default template
-
 void registerCosseratActuatorConstraint(sofa::core::ObjectFactory* factory)
 {
       factory->registerObjects(sofa::core::ObjectRegistrationData("Simulate cable actuation.")

--- a/src/Cosserat/constraint/CosseratNeedleSlidingConstraint.cpp
+++ b/src/Cosserat/constraint/CosseratNeedleSlidingConstraint.cpp
@@ -40,9 +40,9 @@ using namespace sofa::core;
 
 void registerCosseratNeedleSlidingConstraint(
     sofa::core::ObjectFactory *factory) {
-  factory->registerObjects(sofa::core::ObjectRegistrationData("Simulate sliding contraints for needle insertion.")
+  factory->registerObjects(sofa::core::ObjectRegistrationData("Simulate sliding constraints for needle insertion.")
           .add<sofa::component::constraintset::CosseratNeedleSlidingConstraint<sofa::defaulttype::Vec3Types>>(true));
 
 }
 
-} // namespace sofa
+}

--- a/src/Cosserat/constraint/CosseratNeedleSlidingConstraint.cpp
+++ b/src/Cosserat/constraint/CosseratNeedleSlidingConstraint.cpp
@@ -38,12 +38,6 @@ using sofa::defaulttype::Rigid3Types;
 using namespace sofa::helper;
 using namespace sofa::core;
 
-////////////////////////////////////////////    FACTORY    //////////////////////////////////////////////
-// Registering the component
-// see: http://wiki.sofa-framework.org/wiki/ObjectFactory
-// 1-RegisterObject("description") + .add<> : Register the component
-// 2-.add<>(true) : Set default template
-
 void registerCosseratNeedleSlidingConstraint(
     sofa::core::ObjectFactory *factory) {
   factory->registerObjects(sofa::core::ObjectRegistrationData("Simulate sliding contraints for needle insertion.")

--- a/src/Cosserat/constraint/CosseratNeedleSlidingConstraint.cpp
+++ b/src/Cosserat/constraint/CosseratNeedleSlidingConstraint.cpp
@@ -28,20 +28,17 @@
 #include<sofa/defaulttype/VecTypes.h>
 #include <Cosserat/config.h>
 #include <sofa/core/ObjectFactory.h>
-#include "CosseratNeedleSlidingConstraint.inl"
+#include <Cosserat/constraint/CosseratNeedleSlidingConstraint.inl>
 
+template class SOFA_COSSERAT_API sofa::component::constraintset::CosseratNeedleSlidingConstraint<sofa::defaulttype::Vec3Types>;
 
+namespace Cosserat
+{
 
-namespace Cosserat {
-
-using sofa::defaulttype::Rigid3Types;
-using namespace sofa::helper;
-using namespace sofa::core;
-
-void registerCosseratNeedleSlidingConstraint(
-    sofa::core::ObjectFactory *factory) {
-  factory->registerObjects(sofa::core::ObjectRegistrationData("Simulate sliding constraints for needle insertion.")
-          .add<sofa::component::constraintset::CosseratNeedleSlidingConstraint<sofa::defaulttype::Vec3Types>>(true));
+void registerCosseratNeedleSlidingConstraint(sofa::core::ObjectFactory *factory)
+{
+    factory->registerObjects(sofa::core::ObjectRegistrationData("Simulate sliding constraints for needle insertion.")
+        .add<sofa::component::constraintset::CosseratNeedleSlidingConstraint<sofa::defaulttype::Vec3Types>>(true));
 
 }
 

--- a/src/Cosserat/constraint/CosseratNeedleSlidingConstraint.cpp
+++ b/src/Cosserat/constraint/CosseratNeedleSlidingConstraint.cpp
@@ -32,8 +32,7 @@
 
 
 
-namespace sofa::component::constraintset
-{
+namespace Cosserat {
 
 using sofa::defaulttype::Rigid3Types;
 using namespace sofa::helper;
@@ -45,10 +44,11 @@ using namespace sofa::core;
 // 1-RegisterObject("description") + .add<> : Register the component
 // 2-.add<>(true) : Set default template
 
-int CosseratNeedleSlidingConstraintClass = RegisterObject("Simulate sliding contraints for needle insertion.")
-.add< CosseratNeedleSlidingConstraint<sofa::defaulttype::Vec3Types> >(true)
-;
+void registerCosseratNeedleSlidingConstraint(
+    sofa::core::ObjectFactory *factory) {
+  factory->registerObjects(sofa::core::ObjectRegistrationData("Simulate sliding contraints for needle insertion.")
+          .add<sofa::component::constraintset::CosseratNeedleSlidingConstraint<sofa::defaulttype::Vec3Types>>(true));
+
+}
 
 } // namespace sofa
-
-

--- a/src/Cosserat/constraint/CosseratNeedleSlidingConstraint.h
+++ b/src/Cosserat/constraint/CosseratNeedleSlidingConstraint.h
@@ -42,8 +42,6 @@ namespace sofa::component::constraintset
     using sofa::core::behavior::Constraint;
     using sofa::core::objectmodel::Data;
     using sofa::core::visual::VisualParams;
-    using sofa::defaulttype::Vec3dTypes;
-    using sofa::defaulttype::Vec3fTypes;
     using sofa::helper::ReadAccessor;
     using sofa::linearalgebra::BaseVector;
     using sofa::core::MultiVecDerivId ;

--- a/src/Cosserat/constraint/CosseratSlidingConstraint.cpp
+++ b/src/Cosserat/constraint/CosseratSlidingConstraint.cpp
@@ -20,17 +20,18 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #define SOFA_COSSERAT_CPP_CosseratSlidingConstraint
-#include "CosseratSlidingConstraint.inl"
+#include <Cosserat/constraint/CosseratSlidingConstraint.inl>
 
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/core/ObjectFactory.h>
-#include <sofa/component/statecontainer/MechanicalObject.h>
+
+template class SOFA_COSSERAT_API sofa::component::constraintset::CosseratSlidingConstraint<sofa::defaulttype::Vec3Types>;
+
 
 namespace Cosserat
 {
 
 using namespace sofa::defaulttype;
-using namespace sofa::helper;
 
 void registerCosseratSlidingConstraint(sofa::core::ObjectFactory* factory)
 {
@@ -38,8 +39,4 @@ void registerCosseratSlidingConstraint(sofa::core::ObjectFactory* factory)
         .add< sofa::component::constraintset::CosseratSlidingConstraint<Vec3Types> >(true));
 }
 
-}
-namespace sofa::component::constraintset
-{
-  template class CosseratSlidingConstraint<sofa::defaulttype::Vec3dTypes>;
 }

--- a/src/Cosserat/constraint/CosseratSlidingConstraint.cpp
+++ b/src/Cosserat/constraint/CosseratSlidingConstraint.cpp
@@ -26,14 +26,20 @@
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/component/statecontainer/MechanicalObject.h>
 
-namespace sofa::component::constraintset
+namespace Cosserat
 {
 
 using namespace sofa::defaulttype;
 using namespace sofa::helper;
 
-int CosseratSlidingConstraintClass = core::RegisterObject("TODO-CosseratSlidingConstraint")
-        .add< CosseratSlidingConstraint<Vec3Types> >(true);
+void registerCosseratSlidingConstraint(sofa::core::ObjectFactory* factory)
+{
+  factory->registerObjects(sofa::core::ObjectRegistrationData("TODO-CosseratSlidingConstraint")
+        .add< sofa::component::constraintset::CosseratSlidingConstraint<Vec3Types> >(true));
+}
 
-template class CosseratSlidingConstraint<Vec3dTypes>;
+}
+namespace sofa::component::constraintset
+{
+  template class CosseratSlidingConstraint<sofa::defaulttype::Vec3dTypes>;
 }

--- a/src/Cosserat/constraint/QPSlidingConstraint.cpp
+++ b/src/Cosserat/constraint/QPSlidingConstraint.cpp
@@ -35,50 +35,46 @@
 
 //#define SOFTROBOTS_CONSTRAINT_QPSLIDINGCONSTRAINT_NOEXTERN
 
-namespace sofa::component::constraintset
-{
+namespace sofa::component::constraintset {
 
 using sofa::defaulttype::Rigid3Types;
 using namespace sofa::helper;
 using namespace sofa::core;
 
-
 //--------------- Force constraint -------------
-SlidingForceConstraintResolution::SlidingForceConstraintResolution(const double &imposedForce, const double& min, const double& max)
-    : ConstraintResolution(1)
-    , m_imposedForce(imposedForce)
-    , m_minDisplacement(min)
-    , m_maxDisplacement(max)
-{ }
+SlidingForceConstraintResolution::SlidingForceConstraintResolution(
+    const double &imposedForce, const double &min, const double &max)
+    : ConstraintResolution(1), m_imposedForce(imposedForce),
+      m_minDisplacement(min), m_maxDisplacement(max) {}
 
-
-void SlidingForceConstraintResolution::init(int line, double** w, double * lambda)
-{
-    SOFA_UNUSED(lambda);
-    m_wActuatorActuator = w[line][line];
+void SlidingForceConstraintResolution::init(int line, double **w,
+                                            double *lambda) {
+  SOFA_UNUSED(lambda);
+  m_wActuatorActuator = w[line][line];
 }
 
-void SlidingForceConstraintResolution::resolution(int line, double** w, double* d, double* lambda, double* dfree)
-{
-    SOFA_UNUSED(dfree);
-    SOFA_UNUSED(w);
+void SlidingForceConstraintResolution::resolution(int line, double **w,
+                                                  double *d, double *lambda,
+                                                  double *dfree) {
+  SOFA_UNUSED(dfree);
+  SOFA_UNUSED(w);
 
-    double displacement = m_wActuatorActuator*m_imposedForce + d[line];
+  double displacement = m_wActuatorActuator * m_imposedForce + d[line];
 
-    if (displacement<m_minDisplacement)
-    {
-        displacement=m_minDisplacement;
-        lambda[line] -= (d[line]-displacement) / m_wActuatorActuator;
-    }
-    else if (displacement>m_maxDisplacement)
-    {
-        displacement=m_maxDisplacement;
-        lambda[line] -= (d[line]-displacement) / m_wActuatorActuator;
-    }
-    else
-        lambda[line] = m_imposedForce;
+  if (displacement < m_minDisplacement) {
+    displacement = m_minDisplacement;
+    lambda[line] -= (d[line] - displacement) / m_wActuatorActuator;
+  } else if (displacement > m_maxDisplacement) {
+    displacement = m_maxDisplacement;
+    lambda[line] -= (d[line] - displacement) / m_wActuatorActuator;
+  } else
+    lambda[line] = m_imposedForce;
 }
 
+}
+
+namespace Cosserat
+{
 
 ////////////////////////////////////////////    FACTORY    //////////////////////////////////////////////
 // Registering the component
@@ -86,10 +82,13 @@ void SlidingForceConstraintResolution::resolution(int line, double** w, double* 
 // 1-RegisterObject("description") + .add<> : Register the component
 // 2-.add<>(true) : Set default template
 
-int QPSlidingConstraintClass = RegisterObject("Simulate cable actuation.")
-.add< QPSlidingConstraint<sofa::defaulttype::Vec3Types> >(true)
+void registerQPSlidingConstraint(sofa::core::ObjectFactory* factory)
+{
+    factory->registerObjects(sofa::core::ObjectRegistrationData("Simulate cable actuation.")
+    .add< sofa::component::constraintset::QPSlidingConstraint<sofa::defaulttype::Vec3Types> >(true));
+}
 
-;
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // Force template specialization for the most common sofa type.
@@ -99,6 +98,6 @@ int QPSlidingConstraintClass = RegisterObject("Simulate cable actuation.")
 //template class QPSlidingConstraint<sofa::defaulttype::Vec3Types>;
 
 
-} // namespace sofa
+} // namespace Cosserat
 
 

--- a/src/Cosserat/constraint/QPSlidingConstraint.cpp
+++ b/src/Cosserat/constraint/QPSlidingConstraint.cpp
@@ -35,40 +35,48 @@
 
 //#define SOFTROBOTS_CONSTRAINT_QPSLIDINGCONSTRAINT_NOEXTERN
 
-namespace sofa::component::constraintset {
+namespace sofa::component::constraintset
+{
 
 using sofa::defaulttype::Rigid3Types;
 using namespace sofa::helper;
 using namespace sofa::core;
 
-//--------------- Force constraint -------------
-SlidingForceConstraintResolution::SlidingForceConstraintResolution(
-    const double &imposedForce, const double &min, const double &max)
-    : ConstraintResolution(1), m_imposedForce(imposedForce),
-      m_minDisplacement(min), m_maxDisplacement(max) {}
 
-void SlidingForceConstraintResolution::init(int line, double **w,
-                                            double *lambda) {
-  SOFA_UNUSED(lambda);
-  m_wActuatorActuator = w[line][line];
+//--------------- Force constraint -------------
+SlidingForceConstraintResolution::SlidingForceConstraintResolution(const double &imposedForce, const double& min, const double& max)
+    : ConstraintResolution(1)
+    , m_imposedForce(imposedForce)
+    , m_minDisplacement(min)
+    , m_maxDisplacement(max)
+{ }
+
+
+void SlidingForceConstraintResolution::init(int line, double** w, double * lambda)
+{
+    SOFA_UNUSED(lambda);
+    m_wActuatorActuator = w[line][line];
 }
 
-void SlidingForceConstraintResolution::resolution(int line, double **w,
-                                                  double *d, double *lambda,
-                                                  double *dfree) {
-  SOFA_UNUSED(dfree);
-  SOFA_UNUSED(w);
+void SlidingForceConstraintResolution::resolution(int line, double** w, double* d, double* lambda, double* dfree)
+{
+    SOFA_UNUSED(dfree);
+    SOFA_UNUSED(w);
 
-  double displacement = m_wActuatorActuator * m_imposedForce + d[line];
+    double displacement = m_wActuatorActuator*m_imposedForce + d[line];
 
-  if (displacement < m_minDisplacement) {
-    displacement = m_minDisplacement;
-    lambda[line] -= (d[line] - displacement) / m_wActuatorActuator;
-  } else if (displacement > m_maxDisplacement) {
-    displacement = m_maxDisplacement;
-    lambda[line] -= (d[line] - displacement) / m_wActuatorActuator;
-  } else
-    lambda[line] = m_imposedForce;
+    if (displacement<m_minDisplacement)
+    {
+        displacement=m_minDisplacement;
+        lambda[line] -= (d[line]-displacement) / m_wActuatorActuator;
+    }
+    else if (displacement>m_maxDisplacement)
+    {
+        displacement=m_maxDisplacement;
+        lambda[line] -= (d[line]-displacement) / m_wActuatorActuator;
+    }
+    else
+        lambda[line] = m_imposedForce;
 }
 
 //template class QPSlidingConstraint<sofa::defaulttype::Vec3Types>;

--- a/src/Cosserat/constraint/QPSlidingConstraint.cpp
+++ b/src/Cosserat/constraint/QPSlidingConstraint.cpp
@@ -29,8 +29,7 @@
 #include <Cosserat/config.h>
 #include <sofa/core/ObjectFactory.h>
 #include <iostream>
-#include "QPSlidingConstraint.inl"
-
+#include <Cosserat/constraint/QPSlidingConstraint.inl>
 
 
 //#define SOFTROBOTS_CONSTRAINT_QPSLIDINGCONSTRAINT_NOEXTERN
@@ -79,7 +78,7 @@ void SlidingForceConstraintResolution::resolution(int line, double** w, double* 
         lambda[line] = m_imposedForce;
 }
 
-//template class QPSlidingConstraint<sofa::defaulttype::Vec3Types>;
+template class SOFA_COSSERAT_API QPSlidingConstraint<sofa::defaulttype::Vec3Types>;
 }
 
 namespace Cosserat

--- a/src/Cosserat/constraint/QPSlidingConstraint.cpp
+++ b/src/Cosserat/constraint/QPSlidingConstraint.cpp
@@ -71,32 +71,17 @@ void SlidingForceConstraintResolution::resolution(int line, double **w,
     lambda[line] = m_imposedForce;
 }
 
+//template class QPSlidingConstraint<sofa::defaulttype::Vec3Types>;
 }
 
 namespace Cosserat
 {
-
-////////////////////////////////////////////    FACTORY    //////////////////////////////////////////////
-// Registering the component
-// see: http://wiki.sofa-framework.org/wiki/ObjectFactory
-// 1-RegisterObject("description") + .add<> : Register the component
-// 2-.add<>(true) : Set default template
 
 void registerQPSlidingConstraint(sofa::core::ObjectFactory* factory)
 {
     factory->registerObjects(sofa::core::ObjectRegistrationData("Simulate cable actuation.")
     .add< sofa::component::constraintset::QPSlidingConstraint<sofa::defaulttype::Vec3Types> >(true));
 }
-
-
-////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-// Force template specialization for the most common sofa type.
-// This goes with the extern template declaration in the .h. Declaring extern template
-// avoid the code generation of the template for each compilation unit.
-// see: http://www.stroustrup.com/C++11FAQ.html#extern-templates
-//template class QPSlidingConstraint<sofa::defaulttype::Vec3Types>;
-
 
 } // namespace Cosserat
 

--- a/src/Cosserat/constraint/QPSlidingConstraint.h
+++ b/src/Cosserat/constraint/QPSlidingConstraint.h
@@ -42,8 +42,6 @@ namespace sofa::component::constraintset
 
 using sofa::core::visual::VisualParams ;
 using sofa::core::objectmodel::Data ;
-using sofa::defaulttype::Vec3dTypes ;
-using sofa::defaulttype::Vec3fTypes ;
 using sofa::linearalgebra::BaseVector ;
 using sofa::core::ConstraintParams ;
 using sofa::helper::ReadAccessor ;

--- a/src/Cosserat/engine/PointsManager.cpp
+++ b/src/Cosserat/engine/PointsManager.cpp
@@ -1,22 +1,35 @@
-
-#include "PointsManager.inl"
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2019 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <Cosserat/engine/PointsManager.inl>
 #include <sofa/core/ObjectFactory.h>
-#include <sofa/core/visual/VisualParams.h>
-#include <math.h>
-#include <assert.h> /* assert */
 
 namespace Cosserat
 {
 
-    using namespace sofa::defaulttype;
+void registerPointsManager(sofa::core::ObjectFactory* factory)
+{
+    factory->registerObjects(sofa::core::ObjectRegistrationData("add and remove "
+                                                    "points from the state will taking into account the changes inside the modifier and the container")
+                                  .add<sofa::core::behavior::PointsManager>());
+}
 
-    SOFA_DECL_CLASS(PointsManager)
-
-    void registerPointsManager(sofa::core::ObjectFactory* factory)
-    {
-        factory->registerObjects(sofa::core::ObjectRegistrationData("add and remove "
-                                                        "points from the state will taking into account the changes inside the modifier and the container")
-                                      .add<sofa::core::behavior::PointsManager>());
-    }
-
-} // namespace sofa
+} // namespace Cosserat

--- a/src/Cosserat/engine/PointsManager.cpp
+++ b/src/Cosserat/engine/PointsManager.cpp
@@ -5,15 +5,18 @@
 #include <math.h>
 #include <assert.h> /* assert */
 
-namespace sofa::core::behavior
+namespace Cosserat
 {
 
     using namespace sofa::defaulttype;
 
     SOFA_DECL_CLASS(PointsManager)
 
-    int PointsManagerClass = core::RegisterObject("add and remove "
-                                                  "points from the state will taking into account the changes inside the modifier and the container")
-                                .add<PointsManager>();
+    void registerPointsManager(sofa::core::ObjectFactory* factory)
+    {
+        factory->registerObjects(sofa::core::ObjectRegistrationData("add and remove "
+                                                        "points from the state will taking into account the changes inside the modifier and the container")
+                                      .add<sofa::core::behavior::PointsManager>());
+    }
 
 } // namespace sofa

--- a/src/Cosserat/engine/ProjectionEngine.cpp
+++ b/src/Cosserat/engine/ProjectionEngine.cpp
@@ -31,7 +31,6 @@ namespace Cosserat
 {
 
 using namespace sofa::defaulttype;
-using namespace sofa::helper;
 
 void registerProjectionEngine(sofa::core::ObjectFactory *factory) {
   factory->registerObjects(
@@ -44,7 +43,7 @@ void registerProjectionEngine(sofa::core::ObjectFactory *factory) {
 
 namespace sofa::component::constraintset
 {
-    template class ProjectionEngine<defaulttype::Vec3dTypes>;
+    template class SOFA_COSSERAT_API ProjectionEngine<defaulttype::Vec3Types>;
 }
 
 

--- a/src/Cosserat/engine/ProjectionEngine.cpp
+++ b/src/Cosserat/engine/ProjectionEngine.cpp
@@ -27,19 +27,26 @@
 #include <sofa/core/ObjectFactory.h>
 
 
-namespace sofa::component::constraintset
+namespace Cosserat
 {
 
 using namespace sofa::defaulttype;
 using namespace sofa::helper;
 
-int ProjectionEngineClass = core::RegisterObject("TODO-ProjectionEngine")
-        .add< ProjectionEngine<Vec3Types> >(true);
+void registerProjectionEngine(sofa::core::ObjectFactory *factory) {
+  factory->registerObjects(
+      sofa::core::ObjectRegistrationData("TODO-ProjectionEngine")
+          .add<sofa::component::constraintset::ProjectionEngine<Vec3Types>>(
+              true));
+}
 
-template class ProjectionEngine<Vec3dTypes>;
+}
 
+namespace sofa::component::constraintset
+{
+    template class ProjectionEngine<defaulttype::Vec3dTypes>;
+}
 
-} // namespace sofa::component::constraintset
 
 
 

--- a/src/Cosserat/forcefield/BeamHookeLawForceField.cpp
+++ b/src/Cosserat/forcefield/BeamHookeLawForceField.cpp
@@ -172,8 +172,8 @@ void BeamHookeLawForceField<defaulttype::Vec6Types>::addKToMatrix(const Mechanic
 
 using namespace sofa::defaulttype;
 
-template class BeamHookeLawForceField<Vec3Types>;
-template class BeamHookeLawForceField<Vec6Types>;
+template class SOFA_COSSERAT_API BeamHookeLawForceField<Vec3Types>;
+template class SOFA_COSSERAT_API BeamHookeLawForceField<Vec6Types>;
 
 }
 

--- a/src/Cosserat/forcefield/BeamHookeLawForceField.cpp
+++ b/src/Cosserat/forcefield/BeamHookeLawForceField.cpp
@@ -174,14 +174,6 @@ template class BeamHookeLawForceField<Vec6Types>;
 
 namespace Cosserat
 {
-////////////////////////////////////////////    FACTORY    //////////////////////////////////////////////
-// Registering the component
-// see: http://wiki.sofa-framework.org/wiki/ObjectFactory
-// 1-RegisterObject("description") + .add<> : Register the component
-// 2-.add<>(true) : Set default template
-
-
-
 
 void registerBeamHookeLawForceField(sofa::core::ObjectFactory* factory)
 {

--- a/src/Cosserat/forcefield/BeamHookeLawForceField.cpp
+++ b/src/Cosserat/forcefield/BeamHookeLawForceField.cpp
@@ -32,137 +32,142 @@
 
 #include <sofa/core/ObjectFactory.h>
 
-namespace sofa::component::forcefield {
+namespace sofa::component::forcefield
+{
 
-template <> void BeamHookeLawForceField<defaulttype::Vec6Types>::reinit() {
-  // Precompute and store values
-  Real Iy, Iz, J, A;
-  if (d_crossSectionShape.getValue().getSelectedItem() ==
-      "rectangular") // rectangular cross-section
-  {
-    Real Ly = d_lengthY.getValue();
-    Real Lz = d_lengthZ.getValue();
+template<>
+void BeamHookeLawForceField<defaulttype::Vec6Types>::reinit()
+{
+    // Precompute and store values
+    Real Iy, Iz, J, A;
+    if ( d_crossSectionShape.getValue().getSelectedItem() == "rectangular")  //rectangular cross-section
+    {
+        Real Ly = d_lengthY.getValue();
+        Real Lz = d_lengthZ.getValue();
 
-    const Real LyLzLzLz = Ly * Lz * Lz * Lz;
-    const Real LzLyLyLy = Lz * Ly * Ly * Ly;
+        const Real LyLzLzLz = Ly * Lz * Lz * Lz;
+        const Real LzLyLyLy = Lz * Ly * Ly * Ly;
 
-    Iy = LyLzLzLz / 12.0;
-    Iz = LzLyLyLy / 12.0;
-    J = Iy + Iz;
-    A = Ly * Lz;
+        Iy = LyLzLzLz / 12.0;
+        Iz = LzLyLyLy / 12.0;
+        J  = Iy + Iz;
+        A  = Ly * Lz;
 
-  } else // circular cross-section
-  {
-    msg_info() << "Cross section shape."
-               << d_crossSectionShape.getValue().getSelectedItem();
+    }
+    else //circular cross-section
+    {
+        msg_info() << "Cross section shape." << d_crossSectionShape.getValue().getSelectedItem() ;
 
-    Real r = d_radius.getValue();
-    Real rInner = d_innerRadius.getValue();
-    const Real r4 = r * r * r * r;
-    const Real rInner4 = rInner * rInner * rInner * rInner;
+        Real r = d_radius.getValue();
+        Real rInner = d_innerRadius.getValue();
+        const Real r4 = r * r * r * r;
+        const Real rInner4 = rInner * rInner * rInner * rInner;
 
-    Iy = M_PI * (r4 - rInner4) / 4.0;
-    Iz = Iy;
-    J = Iy + Iz;
-    A = M_PI * (r * r - rInner4);
-  }
-  m_crossSectionArea = A;
+        Iy = M_PI * (r4 - rInner4) / 4.0;
+        Iz = Iy;
+        J = Iy + Iz;
+        A = M_PI * (r * r - rInner4);
 
-  if (d_useInertiaParams.getValue()) {
-    msg_info("BeamHookeLawForceField")
-        << "Pre-calculated inertia parameters are used for the computation of the stiffness matrix.";
-    m_K_section66[0][0] = d_GI.getValue();
-    m_K_section66[1][1] = d_EIy.getValue();
-    m_K_section66[2][2] = d_EIz.getValue();
-    m_K_section66[3][3] = d_EA.getValue();
-    m_K_section66[4][4] = d_GA.getValue();
-    m_K_section66[5][5] = d_GA.getValue();
-  } else {
-    // Pour du vec 6, on a  _m_K =diag([G*J E*Iy E*Iz E*A G*As G*As]); % stifness matrix
-    Real E = d_youngModulus.getValue();
-    Real G = E / (2.0 * (1.0 + d_poissonRatio.getValue()));
-    // Translational Stiffness (X, Y, Z directions):
-    //  Gs * J(i): Shearing modulus times the second moment of the area (torsional stiffness). E * Js(i): Young's modulus times the second moment of the area (bending stiffness).
-    m_K_section66[0][0] = G * J;
-    m_K_section66[1][1] = E * Iy;
-    m_K_section66[2][2] = E * Iz;
-    // Rotational Stiffness (X, Y, Z directions):
-    // E * A: Young's modulus times the cross-sectional area (axial stiffness).
-    // Gs * A: Shearing modulus times the cross-sectional area (shearing stiffness).
-    m_K_section66[3][3] = E * A;
-    m_K_section66[4][4] = G * A;
-    m_K_section66[5][5] = G * A;
-  }
+    }
+    m_crossSectionArea = A;
+
+    if( d_useInertiaParams.getValue() )
+    {
+        msg_info("BeamHookeLawForceField")<< "Pre-calculated inertia parameters are used for the computation of the stiffness matrix.";
+        m_K_section66[0][0] = d_GI.getValue();
+        m_K_section66[1][1] = d_EIy.getValue();
+        m_K_section66[2][2] = d_EIz.getValue();
+        m_K_section66[3][3] = d_EA.getValue();
+        m_K_section66[4][4] = d_GA.getValue();
+        m_K_section66[5][5] = d_GA.getValue();
+    }
+    else
+    {
+        //Pour du vec 6, on a  _m_K =diag([G*J E*Iy E*Iz E*A G*As G*As]); % stifness matrix
+        Real E = d_youngModulus.getValue();
+        Real G = E/(2.0*(1.0+d_poissonRatio.getValue()));
+        //Translational Stiffness (X, Y, Z directions):
+        // Gs * J(i): Shearing modulus times the second moment of the area (torsional stiffness).
+        // E * Js(i): Young's modulus times the second moment of the area (bending stiffness).
+        m_K_section66[0][0] = G*J;
+        m_K_section66[1][1] = E*Iy;
+        m_K_section66[2][2] = E*Iz;
+        //Rotational Stiffness (X, Y, Z directions):
+        //E * A: Young's modulus times the cross-sectional area (axial stiffness).
+        //Gs * A: Shearing modulus times the cross-sectional area (shearing stiffness).
+        m_K_section66[3][3] = E*A;
+        m_K_section66[4][4] = G*A;
+        m_K_section66[5][5] = G*A;
+    }
 }
 
-template <>
-void BeamHookeLawForceField<defaulttype::Vec6Types>::addForce(
-    const MechanicalParams *mparams, DataVecDeriv &d_f, const DataVecCoord &d_x,
-    const DataVecDeriv &d_v) {
-  SOFA_UNUSED(d_v);
-  SOFA_UNUSED(mparams);
+template<>
+void BeamHookeLawForceField<defaulttype::Vec6Types>::addForce(const MechanicalParams* mparams,
+                                                      DataVecDeriv& d_f,
+                                                      const DataVecCoord& d_x,
+                                                      const DataVecDeriv& d_v)
+{
+    SOFA_UNUSED(d_v);
+    SOFA_UNUSED(mparams);
 
-  if (!this->getMState()) {
-    msg_info("BeamHookeLawForceField")
-        << "No Mechanical State found, no force will be computed..." << "\n";
-    compute_df = false;
-    return;
-  }
-  VecDeriv &f = *d_f.beginEdit();
-  const VecCoord &x = d_x.getValue();
-  // get the rest position (for non straight shape)
-  const VecCoord &x0 =
-      this->mstate->read(VecCoordId::restPosition())->getValue();
+    if(!this->getMState()) {
+        msg_info("BeamHookeLawForceField") << "No Mechanical State found, no force will be computed..." << "\n";
+        compute_df=false;
+        return;
+    }
+    VecDeriv& f = *d_f.beginEdit();
+    const VecCoord& x = d_x.getValue();
+    // get the rest position (for non straight shape)
+    const VecCoord& x0 = this->mstate->read(VecCoordId::restPosition())->getValue();
 
-  f.resize(x.size());
-  unsigned int sz = d_length.getValue().size();
-  if (x.size() != sz) {
-    msg_warning("BeamHookeLawForceField")
-        << " length : " << sz << "should have the same size as x... "
-        << x.size() << "\n";
-    compute_df = false;
-    return;
-  }
-  for (unsigned int i = 0; i < x.size(); i++)
-    f[i] -= (m_K_section66 * (x[i] - x0[i])) * d_length.getValue()[i];
+    f.resize(x.size());
+    unsigned int sz = d_length.getValue().size();
+    if(x.size()!= sz){
+        msg_warning("BeamHookeLawForceField")<<" length : "<< sz <<"should have the same size as x... "<< x.size() <<"\n";
+        compute_df = false;
+        return;
+    }
+    for (unsigned int i=0; i<x.size(); i++)
+        f[i] -= (m_K_section66 * (x[i] - x0[i])) * d_length.getValue()[i];
 
-  d_f.endEdit();
+    d_f.endEdit();
+
 }
 
-template <>
-void BeamHookeLawForceField<defaulttype::Vec6Types>::addDForce(
-    const MechanicalParams *mparams, DataVecDeriv &d_df,
-    const DataVecDeriv &d_dx) {
-  if (!compute_df)
-    return;
+template<>
+void BeamHookeLawForceField<defaulttype::Vec6Types>::addDForce(const MechanicalParams* mparams,
+                                                       DataVecDeriv&  d_df ,
+                                                       const DataVecDeriv&  d_dx)
+{
+    if (!compute_df)
+        return;
 
-  WriteAccessor<DataVecDeriv> df = d_df;
-  ReadAccessor<DataVecDeriv> dx = d_dx;
-  Real kFactor = (Real)mparams->kFactorIncludingRayleighDamping(
-      this->rayleighStiffness.getValue());
+    WriteAccessor< DataVecDeriv > df = d_df;
+    ReadAccessor< DataVecDeriv > dx = d_dx;
+    Real kFactor = (Real)mparams->kFactorIncludingRayleighDamping(this->rayleighStiffness.getValue());
 
-  df.resize(dx.size());
-  for (unsigned int i = 0; i < dx.size(); i++)
-    df[i] -= (m_K_section66 * dx[i]) * kFactor * d_length.getValue()[i];
+    df.resize(dx.size());
+    for (unsigned int i=0; i<dx.size(); i++)
+        df[i] -= (m_K_section66 * dx[i])*kFactor* d_length.getValue()[i];
 }
 
-template <>
-void BeamHookeLawForceField<defaulttype::Vec6Types>::addKToMatrix(
-    const MechanicalParams *mparams, const MultiMatrixAccessor *matrix) {
-  MultiMatrixAccessor::MatrixRef mref = matrix->getMatrix(this->mstate);
-  BaseMatrix *mat = mref.matrix;
-  unsigned int offset = mref.offset;
-  Real kFact = (Real)mparams->kFactorIncludingRayleighDamping(
-      this->rayleighStiffness.getValue());
+template<>
+void BeamHookeLawForceField<defaulttype::Vec6Types>::addKToMatrix(const MechanicalParams* mparams,
+                                                          const MultiMatrixAccessor* matrix)
+{
+    MultiMatrixAccessor::MatrixRef mref = matrix->getMatrix(this->mstate);
+    BaseMatrix* mat = mref.matrix;
+    unsigned int offset = mref.offset;
+    Real kFact = (Real)mparams->kFactorIncludingRayleighDamping(this->rayleighStiffness.getValue());
 
-  const VecCoord &pos =
-      this->mstate->read(core::ConstVecCoordId::position())->getValue();
-  for (unsigned int n = 0; n < pos.size(); n++) {
-    for (unsigned int i = 0; i < 6; i++)
-      for (unsigned int j = 0; j < 6; j++)
-        mat->add(offset + i + 6 * n, offset + j + 6 * n,
-                 -kFact * m_K_section66[i][j] * d_length.getValue()[n]);
-  }
+    const VecCoord& pos = this->mstate->read(core::ConstVecCoordId::position())->getValue();
+    for (unsigned int n=0; n<pos.size(); n++)
+    {
+        for(unsigned int i = 0; i < 6; i++)
+            for (unsigned int j = 0; j< 6; j++)
+                mat->add(offset + i + 6*n, offset + j + 6*n, -kFact * m_K_section66[i][j]*d_length.getValue()[n]);
+
+    }
 }
 
 using namespace sofa::defaulttype;
@@ -183,12 +188,5 @@ void registerBeamHookeLawForceField(sofa::core::ObjectFactory* factory)
             .add<sofa::component::forcefield::BeamHookeLawForceField<sofa::defaulttype::Vec3Types>>(true)
             .add<sofa::component::forcefield::BeamHookeLawForceField<sofa::defaulttype::Vec6Types>>());
 }
-//////////////////////////////////////////////////////////////////////////////////////////////////////
 
-// Force template specialization for the most common sofa floating point related type.
-// This goes with the extern template declaration in the .h. Declaring extern template
-// avoid the code generation of the template for each compilation unit.
-// see: http://www.stroustrup.com/C++11FAQ.html#extern-templates
-
-
-} // forcefield
+}

--- a/src/Cosserat/forcefield/BeamHookeLawForceField.cpp
+++ b/src/Cosserat/forcefield/BeamHookeLawForceField.cpp
@@ -32,156 +32,165 @@
 
 #include <sofa/core/ObjectFactory.h>
 
-namespace sofa::component::forcefield
-{
+namespace sofa::component::forcefield {
 
-template<>
-void BeamHookeLawForceField<defaulttype::Vec6Types>::reinit()
-{
-    // Precompute and store values
-    Real Iy, Iz, J, A;
-    if ( d_crossSectionShape.getValue().getSelectedItem() == "rectangular")  //rectangular cross-section
-    {
-        Real Ly = d_lengthY.getValue();
-        Real Lz = d_lengthZ.getValue();
+template <> void BeamHookeLawForceField<defaulttype::Vec6Types>::reinit() {
+  // Precompute and store values
+  Real Iy, Iz, J, A;
+  if (d_crossSectionShape.getValue().getSelectedItem() ==
+      "rectangular") // rectangular cross-section
+  {
+    Real Ly = d_lengthY.getValue();
+    Real Lz = d_lengthZ.getValue();
 
-        const Real LyLzLzLz = Ly * Lz * Lz * Lz;
-        const Real LzLyLyLy = Lz * Ly * Ly * Ly;
+    const Real LyLzLzLz = Ly * Lz * Lz * Lz;
+    const Real LzLyLyLy = Lz * Ly * Ly * Ly;
 
-        Iy = LyLzLzLz / 12.0;
-        Iz = LzLyLyLy / 12.0;
-        J  = Iy + Iz;
-        A  = Ly * Lz;
+    Iy = LyLzLzLz / 12.0;
+    Iz = LzLyLyLy / 12.0;
+    J = Iy + Iz;
+    A = Ly * Lz;
 
-    }
-    else //circular cross-section
-    {
-        msg_info() << "Cross section shape." << d_crossSectionShape.getValue().getSelectedItem() ;
+  } else // circular cross-section
+  {
+    msg_info() << "Cross section shape."
+               << d_crossSectionShape.getValue().getSelectedItem();
 
-        Real r = d_radius.getValue();
-        Real rInner = d_innerRadius.getValue();
-        const Real r4 = r * r * r * r;
-        const Real rInner4 = rInner * rInner * rInner * rInner;
+    Real r = d_radius.getValue();
+    Real rInner = d_innerRadius.getValue();
+    const Real r4 = r * r * r * r;
+    const Real rInner4 = rInner * rInner * rInner * rInner;
 
-        Iy = M_PI * (r4 - rInner4) / 4.0;
-        Iz = Iy;
-        J = Iy + Iz;
-        A = M_PI * (r * r - rInner4);
+    Iy = M_PI * (r4 - rInner4) / 4.0;
+    Iz = Iy;
+    J = Iy + Iz;
+    A = M_PI * (r * r - rInner4);
+  }
+  m_crossSectionArea = A;
 
-    }
-    m_crossSectionArea = A;
-
-    if( d_useInertiaParams.getValue() )
-    {
-        msg_info("BeamHookeLawForceField")<< "Pre-calculated inertia parameters are used for the computation of the stiffness matrix.";
-        m_K_section66[0][0] = d_GI.getValue();
-        m_K_section66[1][1] = d_EIy.getValue();
-        m_K_section66[2][2] = d_EIz.getValue();
-        m_K_section66[3][3] = d_EA.getValue();
-        m_K_section66[4][4] = d_GA.getValue();
-        m_K_section66[5][5] = d_GA.getValue();
-    }
-    else
-    {
-        //Pour du vec 6, on a  _m_K =diag([G*J E*Iy E*Iz E*A G*As G*As]); % stifness matrix
-        Real E = d_youngModulus.getValue();
-        Real G = E/(2.0*(1.0+d_poissonRatio.getValue()));
-        //Translational Stiffness (X, Y, Z directions):
-        // Gs * J(i): Shearing modulus times the second moment of the area (torsional stiffness).
-        // E * Js(i): Young's modulus times the second moment of the area (bending stiffness).
-        m_K_section66[0][0] = G*J;
-        m_K_section66[1][1] = E*Iy;
-        m_K_section66[2][2] = E*Iz;
-        //Rotational Stiffness (X, Y, Z directions):
-        //E * A: Young's modulus times the cross-sectional area (axial stiffness).
-        //Gs * A: Shearing modulus times the cross-sectional area (shearing stiffness).
-        m_K_section66[3][3] = E*A;
-        m_K_section66[4][4] = G*A;
-        m_K_section66[5][5] = G*A;
-    }
+  if (d_useInertiaParams.getValue()) {
+    msg_info("BeamHookeLawForceField")
+        << "Pre-calculated inertia parameters are used for the computation of the stiffness matrix.";
+    m_K_section66[0][0] = d_GI.getValue();
+    m_K_section66[1][1] = d_EIy.getValue();
+    m_K_section66[2][2] = d_EIz.getValue();
+    m_K_section66[3][3] = d_EA.getValue();
+    m_K_section66[4][4] = d_GA.getValue();
+    m_K_section66[5][5] = d_GA.getValue();
+  } else {
+    // Pour du vec 6, on a  _m_K =diag([G*J E*Iy E*Iz E*A G*As G*As]); % stifness matrix
+    Real E = d_youngModulus.getValue();
+    Real G = E / (2.0 * (1.0 + d_poissonRatio.getValue()));
+    // Translational Stiffness (X, Y, Z directions):
+    //  Gs * J(i): Shearing modulus times the second moment of the area (torsional stiffness). E * Js(i): Young's modulus times the second moment of the area (bending stiffness).
+    m_K_section66[0][0] = G * J;
+    m_K_section66[1][1] = E * Iy;
+    m_K_section66[2][2] = E * Iz;
+    // Rotational Stiffness (X, Y, Z directions):
+    // E * A: Young's modulus times the cross-sectional area (axial stiffness).
+    // Gs * A: Shearing modulus times the cross-sectional area (shearing stiffness).
+    m_K_section66[3][3] = E * A;
+    m_K_section66[4][4] = G * A;
+    m_K_section66[5][5] = G * A;
+  }
 }
 
-template<>
-void BeamHookeLawForceField<defaulttype::Vec6Types>::addForce(const MechanicalParams* mparams,
-                                                      DataVecDeriv& d_f,
-                                                      const DataVecCoord& d_x,
-                                                      const DataVecDeriv& d_v)
-{
-    SOFA_UNUSED(d_v);
-    SOFA_UNUSED(mparams);
+template <>
+void BeamHookeLawForceField<defaulttype::Vec6Types>::addForce(
+    const MechanicalParams *mparams, DataVecDeriv &d_f, const DataVecCoord &d_x,
+    const DataVecDeriv &d_v) {
+  SOFA_UNUSED(d_v);
+  SOFA_UNUSED(mparams);
 
-    if(!this->getMState()) {
-        msg_info("BeamHookeLawForceField") << "No Mechanical State found, no force will be computed..." << "\n";
-        compute_df=false;
-        return;
-    }
-    VecDeriv& f = *d_f.beginEdit();
-    const VecCoord& x = d_x.getValue();
-    // get the rest position (for non straight shape)
-    const VecCoord& x0 = this->mstate->read(VecCoordId::restPosition())->getValue();
+  if (!this->getMState()) {
+    msg_info("BeamHookeLawForceField")
+        << "No Mechanical State found, no force will be computed..." << "\n";
+    compute_df = false;
+    return;
+  }
+  VecDeriv &f = *d_f.beginEdit();
+  const VecCoord &x = d_x.getValue();
+  // get the rest position (for non straight shape)
+  const VecCoord &x0 =
+      this->mstate->read(VecCoordId::restPosition())->getValue();
 
-    f.resize(x.size());
-    unsigned int sz = d_length.getValue().size();
-    if(x.size()!= sz){
-        msg_warning("BeamHookeLawForceField")<<" length : "<< sz <<"should have the same size as x... "<< x.size() <<"\n";
-        compute_df = false;
-        return;
-    }
-    for (unsigned int i=0; i<x.size(); i++)
-        f[i] -= (m_K_section66 * (x[i] - x0[i])) * d_length.getValue()[i];
+  f.resize(x.size());
+  unsigned int sz = d_length.getValue().size();
+  if (x.size() != sz) {
+    msg_warning("BeamHookeLawForceField")
+        << " length : " << sz << "should have the same size as x... "
+        << x.size() << "\n";
+    compute_df = false;
+    return;
+  }
+  for (unsigned int i = 0; i < x.size(); i++)
+    f[i] -= (m_K_section66 * (x[i] - x0[i])) * d_length.getValue()[i];
 
-    d_f.endEdit();
+  d_f.endEdit();
+}
+
+template <>
+void BeamHookeLawForceField<defaulttype::Vec6Types>::addDForce(
+    const MechanicalParams *mparams, DataVecDeriv &d_df,
+    const DataVecDeriv &d_dx) {
+  if (!compute_df)
+    return;
+
+  WriteAccessor<DataVecDeriv> df = d_df;
+  ReadAccessor<DataVecDeriv> dx = d_dx;
+  Real kFactor = (Real)mparams->kFactorIncludingRayleighDamping(
+      this->rayleighStiffness.getValue());
+
+  df.resize(dx.size());
+  for (unsigned int i = 0; i < dx.size(); i++)
+    df[i] -= (m_K_section66 * dx[i]) * kFactor * d_length.getValue()[i];
+}
+
+template <>
+void BeamHookeLawForceField<defaulttype::Vec6Types>::addKToMatrix(
+    const MechanicalParams *mparams, const MultiMatrixAccessor *matrix) {
+  MultiMatrixAccessor::MatrixRef mref = matrix->getMatrix(this->mstate);
+  BaseMatrix *mat = mref.matrix;
+  unsigned int offset = mref.offset;
+  Real kFact = (Real)mparams->kFactorIncludingRayleighDamping(
+      this->rayleighStiffness.getValue());
+
+  const VecCoord &pos =
+      this->mstate->read(core::ConstVecCoordId::position())->getValue();
+  for (unsigned int n = 0; n < pos.size(); n++) {
+    for (unsigned int i = 0; i < 6; i++)
+      for (unsigned int j = 0; j < 6; j++)
+        mat->add(offset + i + 6 * n, offset + j + 6 * n,
+                 -kFact * m_K_section66[i][j] * d_length.getValue()[n]);
+  }
+}
+
+using namespace sofa::defaulttype;
+
+template class BeamHookeLawForceField<Vec3Types>;
+template class BeamHookeLawForceField<Vec6Types>;
 
 }
 
-template<>
-void BeamHookeLawForceField<defaulttype::Vec6Types>::addDForce(const MechanicalParams* mparams,
-                                                       DataVecDeriv&  d_df ,
-                                                       const DataVecDeriv&  d_dx)
+namespace Cosserat
 {
-    if (!compute_df)
-        return;
-
-    WriteAccessor< DataVecDeriv > df = d_df;
-    ReadAccessor< DataVecDeriv > dx = d_dx;
-    Real kFactor = (Real)mparams->kFactorIncludingRayleighDamping(this->rayleighStiffness.getValue());
-
-    df.resize(dx.size());
-    for (unsigned int i=0; i<dx.size(); i++)
-        df[i] -= (m_K_section66 * dx[i])*kFactor* d_length.getValue()[i];
-}
-
-template<>
-void BeamHookeLawForceField<defaulttype::Vec6Types>::addKToMatrix(const MechanicalParams* mparams,
-                                                          const MultiMatrixAccessor* matrix)
-{
-    MultiMatrixAccessor::MatrixRef mref = matrix->getMatrix(this->mstate);
-    BaseMatrix* mat = mref.matrix;
-    unsigned int offset = mref.offset;
-    Real kFact = (Real)mparams->kFactorIncludingRayleighDamping(this->rayleighStiffness.getValue());
-
-    const VecCoord& pos = this->mstate->read(core::ConstVecCoordId::position())->getValue();
-    for (unsigned int n=0; n<pos.size(); n++)
-    {
-        for(unsigned int i = 0; i < 6; i++)
-            for (unsigned int j = 0; j< 6; j++)
-                mat->add(offset + i + 6*n, offset + j + 6*n, -kFact * m_K_section66[i][j]*d_length.getValue()[n]);
-
-    }
-}
-
 ////////////////////////////////////////////    FACTORY    //////////////////////////////////////////////
 // Registering the component
 // see: http://wiki.sofa-framework.org/wiki/ObjectFactory
 // 1-RegisterObject("description") + .add<> : Register the component
 // 2-.add<>(true) : Set default template
-using namespace sofa::defaulttype;
 
-int BeamHookeLawForceFieldClass = core::RegisterObject("This component is used to compute internal stress for torsion (along x) and bending (y and z)")
-                                      .add<BeamHookeLawForceField<Vec3Types> >(true)
-                                      .add<BeamHookeLawForceField<Vec6Types> >()
 
-    ;
+
+
+void registerBeamHookeLawForceField(sofa::core::ObjectFactory* factory)
+{
+    factory->registerObjects(
+        sofa::core::ObjectRegistrationData(
+            "This component is used to compute internal stress for torsion (along x) and bending (y and z)")
+            .add<sofa::component::forcefield::BeamHookeLawForceField<sofa::defaulttype::Vec3Types>>(true)
+            .add<sofa::component::forcefield::BeamHookeLawForceField<sofa::defaulttype::Vec6Types>>());
+}
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // Force template specialization for the most common sofa floating point related type.
@@ -189,7 +198,5 @@ int BeamHookeLawForceFieldClass = core::RegisterObject("This component is used t
 // avoid the code generation of the template for each compilation unit.
 // see: http://www.stroustrup.com/C++11FAQ.html#extern-templates
 
-template class BeamHookeLawForceField<Vec3Types>;
-template class BeamHookeLawForceField<Vec6Types>;
 
 } // forcefield

--- a/src/Cosserat/forcefield/BeamHookeLawForceFieldRigid.cpp
+++ b/src/Cosserat/forcefield/BeamHookeLawForceFieldRigid.cpp
@@ -37,12 +37,6 @@ using namespace sofa::defaulttype;
 namespace Cosserat
 {
 
-////////////////////////////////////////////    FACTORY    //////////////////////////////////////////////
-// Registering the component
-// see: http://wiki.sofa-framework.org/wiki/ObjectFactory
-// 1-RegisterObject("description") + .add<> : Register the component
-// 2-.add<>(true) : Set default template
-
 void registerBeamHookeLawForceFieldRigid(sofa::core::ObjectFactory *factory) {
   factory->registerObjects(
       sofa::core::ObjectRegistrationData(

--- a/src/Cosserat/forcefield/BeamHookeLawForceFieldRigid.cpp
+++ b/src/Cosserat/forcefield/BeamHookeLawForceFieldRigid.cpp
@@ -45,9 +45,7 @@ void registerBeamHookeLawForceFieldRigid(sofa::core::ObjectFactory *factory) {
           .add<sofa::component::forcefield::BeamHookeLawForceFieldRigid<
               Vec6Types>>());
 }
-//////////////////////////////////////////////////////////////////////////////////////////////////////
 
-// Force template specialization for the most common sofa floating point related type. This goes with the extern template declaration in the .h. Declaring extern template avoid the code generation of the template for each compilation unit. see: http://www.stroustrup.com/C++11FAQ.html#extern-templates
 }
 
 namespace sofa::component::forcefield

--- a/src/Cosserat/forcefield/BeamHookeLawForceFieldRigid.cpp
+++ b/src/Cosserat/forcefield/BeamHookeLawForceFieldRigid.cpp
@@ -34,9 +34,8 @@
 
 using namespace sofa::defaulttype;
 
-namespace sofa::component::forcefield
+namespace Cosserat
 {
-
 
 ////////////////////////////////////////////    FACTORY    //////////////////////////////////////////////
 // Registering the component
@@ -44,20 +43,21 @@ namespace sofa::component::forcefield
 // 1-RegisterObject("description") + .add<> : Register the component
 // 2-.add<>(true) : Set default template
 
-
-int BeamHookeLawForceFieldRigidClass = core::RegisterObject("This component is used to compute internal stress for torsion "
-                                                       "(along x) and bending (y and z)")
-        .add<BeamHookeLawForceFieldRigid<Vec6Types> >()
-        ;
+void registerBeamHookeLawForceFieldRigid(sofa::core::ObjectFactory *factory) {
+  factory->registerObjects(
+      sofa::core::ObjectRegistrationData(
+          "This component is used to compute internal stress for torsion "
+          "(along x) and bending (y and z)")
+          .add<sofa::component::forcefield::BeamHookeLawForceFieldRigid<
+              Vec6Types>>());
+}
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 
-// Force template specialization for the most common sofa floating point related type.
-// This goes with the extern template declaration in the .h. Declaring extern template
-// avoid the code generation of the template for each compilation unit.
-// see: http://www.stroustrup.com/C++11FAQ.html#extern-templates
+// Force template specialization for the most common sofa floating point related type. This goes with the extern template declaration in the .h. Declaring extern template avoid the code generation of the template for each compilation unit. see: http://www.stroustrup.com/C++11FAQ.html#extern-templates
+}
 
-template class SOFA_COSSERAT_API BeamHookeLawForceFieldRigid<Vec6Types>;
-
-
+namespace sofa::component::forcefield
+{
+    template class SOFA_COSSERAT_API BeamHookeLawForceFieldRigid<Vec6Types>;
 
 } // sofa::component::forcefield

--- a/src/Cosserat/forcefield/CosseratInternalActuation.cpp
+++ b/src/Cosserat/forcefield/CosseratInternalActuation.cpp
@@ -42,11 +42,10 @@ void registerCosseratInternalActuation(sofa::core::ObjectFactory *factory) {
           "This component is used to compute internal stress for torsion (along x) and bending (y and z)")
           .add<sofa::component::forcefield::CosseratInternalActuation<Vec3Types>>(true));
 }
-//////////////////////////////////////////////////////////////////////////////////////////////////////
 
 }
 
 namespace sofa::component::forcefield
 {
-    template class CosseratInternalActuation<defaulttype::Vec3Types>;
+    template class SOFA_COSSERAT_API CosseratInternalActuation<defaulttype::Vec3Types>;
 }

--- a/src/Cosserat/forcefield/CosseratInternalActuation.cpp
+++ b/src/Cosserat/forcefield/CosseratInternalActuation.cpp
@@ -31,7 +31,7 @@
 #include <Cosserat/forcefield/CosseratInternalActuation.inl>
 #include <sofa/core/ObjectFactory.h>
 
-namespace sofa::component::forcefield
+namespace Cosserat
 {
 ////////////////////////////////////////////    FACTORY    //////////////////////////////////////////////
 // Registering the component
@@ -40,18 +40,18 @@ namespace sofa::component::forcefield
 // 2-.add<>(true) : Set default template
 using namespace sofa::defaulttype;
 
-int CosseratInternalActuationClass = core::RegisterObject("This component is used to compute internal stress for torsion (along x) and bending (y and z)")
-        .add<CosseratInternalActuation<Vec3Types> >(true)
-
-        ;
+void registerCosseratInternalActuation(sofa::core::ObjectFactory *factory) {
+  factory->registerObjects(
+     sofa::core::ObjectRegistrationData(
+          "This component is used to compute internal stress for torsion (along x) and bending (y and z)")
+          .add<sofa::component::forcefield::CosseratInternalActuation<Vec3Types>>(true));
+}
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 
-// Force template specialization for the most common sofa floating point related type.
-// This goes with the extern template declaration in the .h. Declaring extern template
-// avoid the code generation of the template for each compilation unit.
-// see: http://www.stroustrup.com/C++11FAQ.html#extern-templates
+}
 
-template class CosseratInternalActuation<Vec3Types>;
-
-
+namespace sofa::component::forcefield
+{
+// Force template specialization for the most common sofa floating point related type. This goes with the extern template declaration in the .h. Declaring extern template avoid the code generation of the template for each compilation unit. see: http://www.stroustrup.com/C++11FAQ.html#extern-templates
+    template class CosseratInternalActuation<defaulttype::Vec3Types>;
 }

--- a/src/Cosserat/forcefield/CosseratInternalActuation.cpp
+++ b/src/Cosserat/forcefield/CosseratInternalActuation.cpp
@@ -33,11 +33,7 @@
 
 namespace Cosserat
 {
-////////////////////////////////////////////    FACTORY    //////////////////////////////////////////////
-// Registering the component
-// see: http://wiki.sofa-framework.org/wiki/ObjectFactory
-// 1-RegisterObject("description") + .add<> : Register the component
-// 2-.add<>(true) : Set default template
+
 using namespace sofa::defaulttype;
 
 void registerCosseratInternalActuation(sofa::core::ObjectFactory *factory) {

--- a/src/Cosserat/forcefield/CosseratInternalActuation.cpp
+++ b/src/Cosserat/forcefield/CosseratInternalActuation.cpp
@@ -48,6 +48,5 @@ void registerCosseratInternalActuation(sofa::core::ObjectFactory *factory) {
 
 namespace sofa::component::forcefield
 {
-// Force template specialization for the most common sofa floating point related type. This goes with the extern template declaration in the .h. Declaring extern template avoid the code generation of the template for each compilation unit. see: http://www.stroustrup.com/C++11FAQ.html#extern-templates
     template class CosseratInternalActuation<defaulttype::Vec3Types>;
 }

--- a/src/Cosserat/initCosserat.cpp
+++ b/src/Cosserat/initCosserat.cpp
@@ -37,6 +37,25 @@ using sofa::helper::system::PluginManager;
 // "cosserat" or sofacosserat if you rename the plugin into SofaCosserat :)
 namespace Cosserat {
 
+
+#ifdef COSSERAT_USES_SOFTROBOTS
+extern void registerQPSlidingConstraint(sofa::core::ObjectFactory* factory);
+extern void registerCosseratActuatorConstraint(sofa::core::ObjectFactory* factory);
+#endif
+
+extern void registerCosseratNeedleSlidingConstraint(sofa::core::ObjectFactory* factory);
+extern void registerCosseratSlidingConstraint(sofa::core::ObjectFactory* factory);
+extern void registerPointsManager(sofa::core::ObjectFactory* factory);
+extern void registerProjectionEngine(sofa::core::ObjectFactory* factory);
+extern void registerBeamHookeLawForceField(sofa::core::ObjectFactory* factory);
+extern void registerBeamHookeLawForceFieldRigid(sofa::core::ObjectFactory* factory);
+extern void registerCosseratInternalActuation(sofa::core::ObjectFactory* factory);
+extern void registerDifferenceMultiMapping(sofa::core::ObjectFactory* factory);
+extern void registerDiscreteCosseratMapping(sofa::core::ObjectFactory* factory);
+extern void registerDiscretDynamicCosseratMapping(sofa::core::ObjectFactory* factory);
+extern void registerLegendrePolynomialsMapping(sofa::core::ObjectFactory* factory);
+extern void registerRigidDistanceMapping(sofa::core::ObjectFactory* factory);
+
 extern "C" {
 SOFA_COSSERAT_API void initExternalModule();
 SOFA_COSSERAT_API const char *getModuleLicense();
@@ -44,6 +63,7 @@ SOFA_COSSERAT_API const char *getModuleName();
 SOFA_COSSERAT_API const char *getModuleVersion();
 SOFA_COSSERAT_API const char *getModuleDescription();
 SOFA_COSSERAT_API const char *getModuleComponentList();
+SOFA_COSSERAT_API void registerObjects(sofa::core::ObjectFactory* factory);
 }
 
 // Here are just several convenient functions to help user to know what contains
@@ -51,11 +71,14 @@ SOFA_COSSERAT_API const char *getModuleComponentList();
 
 void initExternalModule() {
   static bool first = true;
-  if (first) {
+  if (first)
+  {
+    sofa::helper::system::PluginManager::getInstance().registerPlugin(MODULE_NAME);
     first = false;
   }
   // Automatically load the STLIB plugin if available.
-  if (!PluginManager::getInstance().findPlugin("STLIB").empty()) {
+  if (!PluginManager::getInstance().findPlugin("STLIB").empty())
+  {
     PluginManager::getInstance().loadPlugin("STLIB");
   }
 
@@ -63,6 +86,23 @@ void initExternalModule() {
   PythonEnvironment::addPythonModulePathsForPluginsByName("Cosserat");
 #endif
 }
+
+void registerObjects(sofa::core::ObjectFactory* factory)
+{
+  registerCosseratNeedleSlidingConstraint(factory);
+  registerCosseratSlidingConstraint(factory);
+  registerPointsManager(factory);
+  registerProjectionEngine(factory);
+  registerBeamHookeLawForceField(factory);
+  registerBeamHookeLawForceFieldRigid(factory);
+  registerCosseratInternalActuation(factory);
+  registerDifferenceMultiMapping(factory);
+  registerDiscreteCosseratMapping(factory);
+  registerDiscretDynamicCosseratMapping(factory);
+  registerLegendrePolynomialsMapping(factory);
+  registerRigidDistanceMapping(factory);
+}
+
 const char *getModuleLicense() { return "LGPL"; }
 
 const char *getModuleName() { return Cosserat::MODULE_NAME; }

--- a/src/Cosserat/initCosserat.cpp
+++ b/src/Cosserat/initCosserat.cpp
@@ -89,6 +89,10 @@ void initExternalModule() {
 
 void registerObjects(sofa::core::ObjectFactory* factory)
 {
+#ifdef COSSERAT_USES_SOFTROBOTS
+  registerQPSlidingConstraint(factory);
+  registerCosseratActuatorConstraint(factory);
+#endif
   registerCosseratNeedleSlidingConstraint(factory);
   registerCosseratSlidingConstraint(factory);
   registerPointsManager(factory);

--- a/src/Cosserat/mapping/BaseCosseratMapping.cpp
+++ b/src/Cosserat/mapping/BaseCosseratMapping.cpp
@@ -26,10 +26,8 @@
 namespace Cosserat::mapping
 {
 template class SOFA_COSSERAT_API
-    BaseCosseratMapping<sofa::defaulttype::Vec3Types, sofa::defaulttype::Rigid3Types,
-                 sofa::defaulttype::Rigid3Types>;
+    BaseCosseratMapping<sofa::defaulttype::Vec3Types, sofa::defaulttype::Rigid3Types, sofa::defaulttype::Rigid3Types>;
 template class SOFA_COSSERAT_API
-    BaseCosseratMapping<sofa::defaulttype::Vec6Types, sofa::defaulttype::Rigid3Types,
-                 sofa::defaulttype::Rigid3Types>;
+    BaseCosseratMapping<sofa::defaulttype::Vec6Types, sofa::defaulttype::Rigid3Types, sofa::defaulttype::Rigid3Types>;
 
 } // namespace cosserat::mapping

--- a/src/Cosserat/mapping/DifferenceMultiMapping.cpp
+++ b/src/Cosserat/mapping/DifferenceMultiMapping.cpp
@@ -25,15 +25,17 @@
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/core/ObjectFactory.h>
 
-namespace Cosserat::mapping
+namespace Cosserat
 {
 
 using namespace sofa::defaulttype;
 
 // Register in the Factory
-int DifferenceMultiMappingClass = sofa::core::RegisterObject("Set the positions and velocities of points attached to a rigid parent")
-        .add< DifferenceMultiMapping< sofa::defaulttype::Vec3Types, sofa::defaulttype::Vec3Types, sofa::defaulttype::Vec3Types > >() ;
-
+void registerDifferenceMultiMapping(sofa::core::ObjectFactory* factory)
+{
+  factory->registerObjects(sofa::core::ObjectRegistrationData("Set the positions and velocities of points attached to a rigid parent")
+        .add< mapping::DifferenceMultiMapping< sofa::defaulttype::Vec3Types, sofa::defaulttype::Vec3Types, sofa::defaulttype::Vec3Types > >()) ;
+}
 
 
 } // namespace sofa.

--- a/src/Cosserat/mapping/DifferenceMultiMapping.cpp
+++ b/src/Cosserat/mapping/DifferenceMultiMapping.cpp
@@ -20,7 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #define SOFA_COSSERAT_CPP_DifferenceMultiMapping
-#include "DifferenceMultiMapping.inl"
+#include <Cosserat/mapping/DifferenceMultiMapping.inl>
 
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/core/ObjectFactory.h>
@@ -30,6 +30,8 @@ namespace Cosserat
 
 using namespace sofa::defaulttype;
 
+template class SOFA_COSSERAT_API mapping::DifferenceMultiMapping< sofa::defaulttype::Vec3Types, sofa::defaulttype::Vec3Types, sofa::defaulttype::Vec3Types >;
+
 // Register in the Factory
 void registerDifferenceMultiMapping(sofa::core::ObjectFactory* factory)
 {
@@ -37,5 +39,4 @@ void registerDifferenceMultiMapping(sofa::core::ObjectFactory* factory)
         .add< mapping::DifferenceMultiMapping< sofa::defaulttype::Vec3Types, sofa::defaulttype::Vec3Types, sofa::defaulttype::Vec3Types > >()) ;
 }
 
-
-} // namespace sofa.
+} // namespace Cosserat

--- a/src/Cosserat/mapping/DiscreteCosseratMapping.cpp
+++ b/src/Cosserat/mapping/DiscreteCosseratMapping.cpp
@@ -357,11 +357,19 @@ void DiscreteCosseratMapping<Vec6Types, Rigid3Types, Rigid3Types>::applyJT(
     }
 }
 
-// Register in the Factory
-int DiscreteCosseratMappingClass = sofa::core::RegisterObject("Set the positions and velocities of points attached to a rigid parent")
-                                       .add< DiscreteCosseratMapping< sofa::defaulttype::Vec3Types, sofa::defaulttype::Rigid3Types, sofa::defaulttype::Rigid3Types > >(true)
-                                       .add< DiscreteCosseratMapping< sofa::defaulttype::Vec6Types, sofa::defaulttype::Rigid3Types, sofa::defaulttype::Rigid3Types > >();
+
 template class SOFA_COSSERAT_API DiscreteCosseratMapping< sofa::defaulttype::Vec3Types, sofa::defaulttype::Rigid3Types, sofa::defaulttype::Rigid3Types >;
 template class SOFA_COSSERAT_API DiscreteCosseratMapping< sofa::defaulttype::Vec6Types, sofa::defaulttype::Rigid3Types, sofa::defaulttype::Rigid3Types >;
 
 } // namespace sofa::component::mapping
+
+namespace Cosserat
+{
+// Register in the Factory
+void registerDiscreteCosseratMapping(sofa::core::ObjectFactory* factory)
+{
+  factory->registerObjects(sofa::core::ObjectRegistrationData("Set the positions and velocities of points attached to a rigid parent")
+                               .add< mapping::DiscreteCosseratMapping< sofa::defaulttype::Vec3Types, sofa::defaulttype::Rigid3Types, sofa::defaulttype::Rigid3Types > >(true)
+                               .add< mapping::DiscreteCosseratMapping< sofa::defaulttype::Vec6Types, sofa::defaulttype::Rigid3Types, sofa::defaulttype::Rigid3Types > >());
+}
+}

--- a/src/Cosserat/mapping/DiscreteDynamicCosseratMapping.cpp
+++ b/src/Cosserat/mapping/DiscreteDynamicCosseratMapping.cpp
@@ -31,11 +31,18 @@ namespace Cosserat::mapping
 
 using namespace sofa::defaulttype;
 
-// Register in the Factory
-int DiscretDynamicCosseratMappingClass = sofa::core::RegisterObject("Set the positions and velocities of points attached to a rigid parent")
-        .add< DiscreteDynamicCosseratMapping< sofa::defaulttype::Vec3Types, sofa::defaulttype::Rigid3Types, sofa::defaulttype::Rigid3Types > >() ;
 
 
 template class SOFA_COSSERAT_API DiscreteDynamicCosseratMapping< sofa::defaulttype::Vec3Types, sofa::defaulttype::Rigid3Types, sofa::defaulttype::Rigid3Types >;
 
 } // namespace sofa::component::mapping
+
+namespace Cosserat
+{
+// Register in the Factory
+void registerDiscretDynamicCosseratMapping(sofa::core::ObjectFactory* factory)
+{
+  factory->registerObjects( sofa::core::ObjectRegistrationData("Set the positions and velocities of points attached to a rigid parent")
+          .add<mapping::DiscreteDynamicCosseratMapping<sofa::defaulttype::Vec3Types, sofa::defaulttype::Rigid3Types, sofa::defaulttype::Rigid3Types>>());
+}
+}

--- a/src/Cosserat/mapping/DiscreteDynamicCosseratMapping.cpp
+++ b/src/Cosserat/mapping/DiscreteDynamicCosseratMapping.cpp
@@ -26,23 +26,16 @@
 #include <sofa/defaulttype/RigidTypes.h>
 #include <sofa/core/ObjectFactory.h>
 
-namespace Cosserat::mapping
-{
-
-using namespace sofa::defaulttype;
-
-
-
-template class SOFA_COSSERAT_API DiscreteDynamicCosseratMapping< sofa::defaulttype::Vec3Types, sofa::defaulttype::Rigid3Types, sofa::defaulttype::Rigid3Types >;
-
-} // namespace sofa::component::mapping
-
 namespace Cosserat
 {
+
+template class SOFA_COSSERAT_API mapping::DiscreteDynamicCosseratMapping< sofa::defaulttype::Vec3Types, sofa::defaulttype::Rigid3Types, sofa::defaulttype::Rigid3Types >;
+
 // Register in the Factory
 void registerDiscretDynamicCosseratMapping(sofa::core::ObjectFactory* factory)
 {
   factory->registerObjects( sofa::core::ObjectRegistrationData("Set the positions and velocities of points attached to a rigid parent")
           .add<mapping::DiscreteDynamicCosseratMapping<sofa::defaulttype::Vec3Types, sofa::defaulttype::Rigid3Types, sofa::defaulttype::Rigid3Types>>());
 }
+
 }

--- a/src/Cosserat/mapping/LegendrePolynomialsMapping.cpp
+++ b/src/Cosserat/mapping/LegendrePolynomialsMapping.cpp
@@ -1,16 +1,37 @@
-//
-// Created by younes on 17/11/2021.
-//
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2019 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
 #define SOFA_COSSERAT_CPP_LegendrePolynomialsMapping
-#include "LegendrePolynomialsMapping.inl"
+#include <Cosserat/mapping/LegendrePolynomialsMapping.inl>
 
 #include <sofa/defaulttype/VecTypes.h>
-#include <sofa/defaulttype/RigidTypes.h>
 #include <sofa/core/ObjectFactory.h>
+
+namespace sofa::component::mapping
+{
+    template class SOFA_COSSERAT_API LegendrePolynomialsMapping< sofa::defaulttype::Vec3Types, sofa::defaulttype::Vec3Types >;
+}
 
 namespace Cosserat
 {
-using namespace sofa::defaulttype;
 
 // Register in the Factory
 void registerLegendrePolynomialsMapping(sofa::core::ObjectFactory* factory) {
@@ -18,9 +39,5 @@ void registerLegendrePolynomialsMapping(sofa::core::ObjectFactory* factory) {
             .add<sofa::component::mapping::LegendrePolynomialsMapping<sofa::defaulttype::Vec3Types, sofa::defaulttype::Vec3Types>>());
 }
 
-} // namespace sofa::component::mapping
-
-namespace sofa::component::mapping
-{
-    template class SOFA_COSSERAT_API LegendrePolynomialsMapping< sofa::defaulttype::Vec3Types, sofa::defaulttype::Vec3Types >;
 }
+

--- a/src/Cosserat/mapping/LegendrePolynomialsMapping.cpp
+++ b/src/Cosserat/mapping/LegendrePolynomialsMapping.cpp
@@ -8,12 +8,19 @@
 #include <sofa/defaulttype/RigidTypes.h>
 #include <sofa/core/ObjectFactory.h>
 
+namespace Cosserat
+{
+using namespace sofa::defaulttype;
+
+// Register in the Factory
+void registerLegendrePolynomialsMapping(sofa::core::ObjectFactory* factory) {
+    factory->registerObjects(sofa::core::ObjectRegistrationData("Set the positions and velocities of points attached to a rigid parent")
+            .add<sofa::component::mapping::LegendrePolynomialsMapping<sofa::defaulttype::Vec3Types, sofa::defaulttype::Vec3Types>>());
+}
+
+} // namespace sofa::component::mapping
+
 namespace sofa::component::mapping
 {
-    using namespace defaulttype;
-
-    // Register in the Factory
-    int LegendrePolynomialsMappingClass = core::RegisterObject("Set the positions and velocities of points attached to a rigid parent")
-                                   .add< LegendrePolynomialsMapping< sofa::defaulttype::Vec3Types, sofa::defaulttype::Vec3Types > >() ;
     template class SOFA_COSSERAT_API LegendrePolynomialsMapping< sofa::defaulttype::Vec3Types, sofa::defaulttype::Vec3Types >;
-} // namespace sofa::component::mapping
+}

--- a/src/Cosserat/mapping/RigidDistanceMapping.cpp
+++ b/src/Cosserat/mapping/RigidDistanceMapping.cpp
@@ -27,11 +27,17 @@
 namespace Cosserat::mapping
 {
 
-// Register in the Factory
-int RigidDistanceMappingClass = sofa::core::RegisterObject("Maps two rigid frames to a single rigid frame representing their differences")
-        .add< RigidDistanceMapping< sofa::defaulttype::Rigid3Types, sofa::defaulttype::Rigid3Types, sofa::defaulttype::Rigid3Types > >() ;
-
-
 template class SOFA_COSSERAT_API RigidDistanceMapping< sofa::defaulttype::Rigid3Types, sofa::defaulttype::Rigid3Types, sofa::defaulttype::Rigid3Types >;
 
 } // namespace Cosserat::mapping
+
+namespace Cosserat
+{
+
+// Register in the Factory
+void registerRigidDistanceMapping(sofa::core::ObjectFactory* factory)
+{
+  factory->registerObjects(sofa::core::ObjectRegistrationData("Maps two rigid frames to a single rigid frame representing their differences")
+                               .add< mapping::RigidDistanceMapping< sofa::defaulttype::Rigid3Types, sofa::defaulttype::Rigid3Types, sofa::defaulttype::Rigid3Types > >()) ;
+}
+}


### PR DESCRIPTION
This applies the new factory registration mechanism as introduced by [[All] ObjectFactory: Explicit components registration  #4429 ](https://github.com/sofa-framework/sofa/pull/4429)

In the process I've encountered a problem of consistency of namespace. I needed all of the registering methods to be in the `Cosserat` namespace. But a lot of SOFA namespace are used. This is bad practice, only the Cosserat namespace should be used in this plugin.

 